### PR TITLE
Skip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ The TestCafe version to install.
     args: "chrome tests"
 ```
 
-If you are managing TestCafe already in your package.json dependencies and want to use that version, you can specify ``null`` as the version for this action and it will use the existing installation.
-
-```yaml
-- uses: DevExpress/testcafe-action@latest
-  with:
-    version: null
-    args: "chrome tests"
-```
-
 **Default value:** `latest`
 
 ### skip-install

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ If you are managing TestCafe already in your package.json dependencies and want 
 
 **Default value:** `latest`
 
+### skip-install
+
+*Optional*
+
+Whether to skip having this action install TestCafe. This is useful if you are managing TestCafe already in your package.json dependencies and want to use that version.
+
+```yaml
+- uses: DevExpress/testcafe-action@latest
+  with:
+    skip-install: true
+    args: "chrome tests"
+```
+
+**Default value:** `false`
+
 ## Examples
 
 This section contains sample workflows that show how to use `testcafe-action`.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ The TestCafe version to install.
     args: "chrome tests"
 ```
 
+If you are managing TestCafe already in your package.json dependencies and want to use that version, you can specify ``null`` as the version for this action and it will use the existing installation.
+
+```yaml
+- uses: DevExpress/testcafe-action@latest
+  with:
+    version: null
+    args: "chrome tests"
+```
+
 **Default value:** `latest`
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Branch in the TestCafe repository to check out. The action builds TestCafe from this branch'
   commit:
     description: 'Commit in the TestCafe repository to check out. The action builds TestCafe from this commit'
+  skip-install:
+    description: 'Skip installation of TestCafe and use a previously installed version.'
+    default: false
   args:
     description: 'Command line arguments passed to TestCafe'
     required: true

--- a/index.js
+++ b/index.js
@@ -18,6 +18,13 @@ const testCafeArguments = getInput('args');
 const version   = getInput('version');
 const branch    = getInput('branch');
 const commit    = getInput('commit');
+let skipInstall = getInput('skip-install')
+if (skipInstall === 'true') {
+    skipInstall = true;
+}
+if (skipInstall !== true) {
+    skipInstall = false;
+}
 const branchCmd = branch && !commit ? `-b ${branch}` : '';
 
 const gitCloneCmd    = `git clone https://github.com/DevExpress/testcafe.git ${branchCmd}`;
@@ -28,29 +35,31 @@ let testCafeCmd = '';
 log(`VERSION: ${getInputStr(version)}`);
 log(`BRANCH: ${getInputStr(branch)}`);
 log(`COMMIT: ${getInputStr(commit)}`);
+log(`SKIP INSTALL: ${skipInstall}`);
 
 if (branch || commit) {
-    log('Cloning the TestCafe repository...');
-    log(gitCloneCmd);
-    execSync(gitCloneCmd, { stdio: 'inherit' });
-
-    log('Checking out the repository...');
-    log(gitCheckoutCmd);
-    execSync(gitCheckoutCmd, { stdio: 'inherit' });
-
-    log('Installing npm packages...');
-    execSync(`cd testcafe && npm install `, { stdio: 'inherit' });
-
-    log('Building TestCafe...');
-    execSync(`cd testcafe && npx gulp fast-build`, { stdio: 'inherit' });
-
+    if (!skipInstall) {
+        log('Cloning the TestCafe repository...');
+        log(gitCloneCmd);
+        execSync(gitCloneCmd, { stdio: 'inherit' });
+    
+        log('Checking out the repository...');
+        log(gitCheckoutCmd);
+        execSync(gitCheckoutCmd, { stdio: 'inherit' });
+    
+        log('Installing npm packages...');
+        execSync(`cd testcafe && npm install `, { stdio: 'inherit' });
+    
+        log('Building TestCafe...');
+        execSync(`cd testcafe && npx gulp fast-build`, { stdio: 'inherit' });
+    }
     testCafeCmd = 'node testcafe/bin/testcafe';
 }
 else {
-    log('Installing TestCafe from npm...');
-
-    execSync(`npm i testcafe@${version}`);
-
+    if (!skipInstall) {
+        log('Installing TestCafe from npm...');
+        execSync(`npm i testcafe@${version}`);
+    }
     testCafeCmd = 'npx testcafe';
 }
 

--- a/index.js
+++ b/index.js
@@ -18,13 +18,7 @@ const testCafeArguments = getInput('args');
 const version   = getInput('version');
 const branch    = getInput('branch');
 const commit    = getInput('commit');
-let skipInstall = getInput('skip-install')
-if (skipInstall === 'true') {
-    skipInstall = true;
-}
-if (skipInstall !== true) {
-    skipInstall = false;
-}
+const skipInstall = getInput('skip-install') === true
 const branchCmd = branch && !commit ? `-b ${branch}` : '';
 
 const gitCloneCmd    = `git clone https://github.com/DevExpress/testcafe.git ${branchCmd}`;
@@ -38,21 +32,19 @@ log(`COMMIT: ${getInputStr(commit)}`);
 log(`SKIP INSTALL: ${skipInstall}`);
 
 if (branch || commit) {
-    if (!skipInstall) {
-        log('Cloning the TestCafe repository...');
-        log(gitCloneCmd);
-        execSync(gitCloneCmd, { stdio: 'inherit' });
-    
-        log('Checking out the repository...');
-        log(gitCheckoutCmd);
-        execSync(gitCheckoutCmd, { stdio: 'inherit' });
-    
-        log('Installing npm packages...');
-        execSync(`cd testcafe && npm install `, { stdio: 'inherit' });
-    
-        log('Building TestCafe...');
-        execSync(`cd testcafe && npx gulp fast-build`, { stdio: 'inherit' });
-    }
+    log('Cloning the TestCafe repository...');
+    log(gitCloneCmd);
+    execSync(gitCloneCmd, { stdio: 'inherit' });
+
+    log('Checking out the repository...');
+    log(gitCheckoutCmd);
+    execSync(gitCheckoutCmd, { stdio: 'inherit' });
+
+    log('Installing npm packages...');
+    execSync(`cd testcafe && npm install `, { stdio: 'inherit' });
+
+    log('Building TestCafe...');
+    execSync(`cd testcafe && npx gulp fast-build`, { stdio: 'inherit' });
     testCafeCmd = 'node testcafe/bin/testcafe';
 }
 else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-action",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We manage our dependencies strictly through package.json and use `npm ci` during github actions to ensure a deterministic dependency environment.  

We enjoy the addition of the xvfb command that the TestCafe action provides (and hopefully future functionality to run tests in Windows and Mac as well). But we want to be able to skip this action installing any dependencies, as that can result in a run taking place with different sub-dependencies than were originally specified in our package-lock.json.  

By specifying `skip-install` argument as `true`, the action will no longer attempt to install TestCafe itself, and will rely on the pre-existing installation.

This has been verified to work in this GitHub action that was run a few minutes ago: https://github.com/CuriBio/mantarray-frontend-components/actions/runs/590022214