### PR TITLE
Update to use node16 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'Command line arguments passed to TestCafe'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
The `node12` runner has been deprecated ([see GitHub blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)). Whenever this action is used, it emits an annotation, warning about this deprecation.